### PR TITLE
fix(storagehandler): minification removes constructor.name and fails description

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install
@@ -50,7 +50,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,8 +22,8 @@ const getConfig = (type, color = 'blue', coverage = false) => {
 
 const jestConfig = {
   projects: [
-    getConfig('unit', 'blue', Boolean(process.env.COVERAGE)),
-    getConfig('feat', 'orange', Boolean(process.env.COVERAGE)),
+    getConfig('unit', 'cyan', Boolean(process.env.COVERAGE)),
+    getConfig('feat', 'magentaBright', Boolean(process.env.COVERAGE)),
   ],
 }
 

--- a/src/storage/handler.ts
+++ b/src/storage/handler.ts
@@ -41,6 +41,7 @@ export abstract class StorageHandler {
    * storage handler versions.
    */
   static version = 1;
+  static serializer = 'StorageHandler';
 
   key: string;
   di: StorageContext;
@@ -63,7 +64,7 @@ export abstract class StorageHandler {
     const output: Serialized = {
       meta: {
         key: this.key,
-        serializer: constructor.name,
+        serializer: constructor.serializer,
         version: constructor.version,
         datetime: Date.now(),
       },

--- a/src/storage/inMemory.ts
+++ b/src/storage/inMemory.ts
@@ -16,6 +16,7 @@ import {
 export class InMemoryHandler extends StorageHandler {
 
   STORAGE: Serialized | null;
+  static serializer = 'InMemoryHandler';
 
   constructor(key: string, di: StorageContext) {
     super(key, di);

--- a/src/storage/localStorage.ts
+++ b/src/storage/localStorage.ts
@@ -13,6 +13,7 @@ import { StorageHandler, Serialized } from './handler';
  * @constructor
  */
 export class LocalStorageHandler extends StorageHandler {
+  static serializer = 'LocalStorageHandler';
 
   get ls(): Storage {
     return window.localStorage;

--- a/src/storage/sessionStorage.ts
+++ b/src/storage/sessionStorage.ts
@@ -11,6 +11,8 @@ import { StorageHandler, Serialized } from './handler';
  */
 export class SessionStorageHandler extends StorageHandler {
 
+  static serializer = 'SessionStorageHandler';
+
   /**
      * Returns the SessionStorage instance.
      */


### PR DESCRIPTION
Some minification processes obfuscate this.constructor.name. However, StorageHandler is checking the
this.constructor.name at runtime when it validates the encrypted payload. Since there is a mismatch,
decryption doesn't even start.

Closes #35